### PR TITLE
fix: set correct hint annotations for tools

### DIFF
--- a/internal/hbmcp/faults.go
+++ b/internal/hbmcp/faults.go
@@ -16,6 +16,8 @@ func RegisterFaultTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("list_faults",
 			mcp.WithDescription("Get a list of faults for a project with optional filtering and ordering"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to get faults for"),
@@ -56,6 +58,8 @@ func RegisterFaultTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("get_fault",
 			mcp.WithDescription("Get detailed information for a specific fault in a project"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project containing the fault"),
@@ -76,6 +80,8 @@ func RegisterFaultTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("list_fault_notices",
 			mcp.WithDescription("Get a list of notices (individual error events) for a specific fault"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project containing the fault"),
@@ -107,6 +113,8 @@ func RegisterFaultTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("list_fault_affected_users",
 			mcp.WithDescription("Get a list of users who were affected by a specific fault with occurrence counts"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project containing the fault"),
@@ -130,6 +138,8 @@ func RegisterFaultTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("get_fault_counts",
 			mcp.WithDescription("Get fault count statistics for a project with optional filtering"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to get fault counts for"),

--- a/internal/hbmcp/projects.go
+++ b/internal/hbmcp/projects.go
@@ -48,6 +48,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("create_project",
 			mcp.WithDescription("Create a new Honeybadger project"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 			mcp.WithString("account_id",
 				mcp.Required(),
 				mcp.Description("The account ID to associate the project with"),
@@ -88,6 +90,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("update_project",
 			mcp.WithDescription("Update an existing Honeybadger project"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 			mcp.WithNumber("id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to update"),
@@ -127,6 +131,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("delete_project",
 			mcp.WithDescription("Delete a Honeybadger project"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 			mcp.WithNumber("id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to delete"),

--- a/internal/hbmcp/projects.go
+++ b/internal/hbmcp/projects.go
@@ -16,6 +16,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("list_projects",
 			mcp.WithDescription("List all Honeybadger projects"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("account_id",
 				mcp.Description("Optional account ID to filter projects by specific account"),
 			),
@@ -29,6 +31,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("get_project",
 			mcp.WithDescription("Get a single Honeybadger project by ID"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to retrieve"),
@@ -138,6 +142,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("get_project_occurrence_counts",
 			mcp.WithDescription("Get occurrence counts for all projects or a specific project"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Description("Optional project ID to get occurrence counts for a specific project"),
 				mcp.Min(1),
@@ -159,6 +165,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("get_project_integrations",
 			mcp.WithDescription("Get a list of integrations (channels) for a Honeybadger project"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to get integrations for"),
@@ -174,6 +182,8 @@ func RegisterProjectTools(s *server.MCPServer, client *hbapi.Client) {
 	s.AddTool(
 		mcp.NewTool("get_project_report",
 			mcp.WithDescription("Get report data for a Honeybadger project"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithNumber("project_id",
 				mcp.Required(),
 				mcp.Description("The ID of the project to get report data for"),


### PR DESCRIPTION
mcp-go defaults the destructive hint annotation to `true` for all tools. This sets the read-only and destructive hint annotations explicitly for each tool based on its behavior.

Fixes #7 