### PR TITLE
Fix segmentation fault by disabling CGO in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.24.4-alpine AS build
 WORKDIR /build
 COPY . .
-RUN go build -o /bin/honeybadger-mcp-server ./cmd/honeybadger-mcp-server
+RUN CGO_ENABLED=0 go build -o /bin/honeybadger-mcp-server ./cmd/honeybadger-mcp-server
 
 FROM alpine:3
 WORKDIR /server


### PR DESCRIPTION
_Fixes https://github.com/honeybadger-io/honeybadger-mcp-server/issues/20_

The MCP server crashes with a segmentation fault when making API calls via Docker:

```
SIGSEGV: segmentation violation
PC=0x43638e m=7 sigcode=1 addr=0xffffffff58a4c070
goroutine 0 gp=0xc000102700 m=7 mp=0xc000101008 [idle]:
runtime.netpoll(0xc000028000?)
/usr/local/go/src/runtime/netpoll_epoll.go:169 +0x24e
```

**Root cause**: Go's networking code has incompatibility issues with Alpine Linux's musl libc when CGO is enabled.

## Solution

Build with `CGO_ENABLED=0` to create a fully static binary that uses Go's pure-Go network stack, avoiding libc dependencies. This is the standard practice for Go applications in Alpine-based containers.

## Changes

- Modified `Dockerfile` line 4 to add `CGO_ENABLED=0` to the build command
