### PR TITLE
Allow mcp docs in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 .idea/
 e2e/
 **/*.md
+!internal/hbmcp/docs/*.md
 **/*_test.go
 LICENSE
 /honeybadger-mcp-server


### PR DESCRIPTION
The docker build failed because we are not including any markdown files in the image, which we need. This adds an exception for the internal docs.