### PR TITLE
Validate token audience against a configurable resource URL

### DIFF
--- a/cmd/honeybadger-mcp-server/main.go
+++ b/cmd/honeybadger-mcp-server/main.go
@@ -72,6 +72,8 @@ func init() {
 	httpCmd.Flags().Bool("stateless", true, "Run in stateless mode (recommended for horizontally scaled deployments)")
 	httpCmd.Flags().String("public-url", "", "Public origin of this MCP server (e.g. https://mcp.honeybadger.io). Required to advertise OAuth Protected Resource Metadata and serve the 401 discovery challenge")
 	httpCmd.Flags().String("authorization-server", "", "OAuth authorization server origin (e.g. https://app.honeybadger.io). Required when --public-url is set")
+	httpCmd.Flags().String("resource-url", "", "OAuth resource identifier advertised in PRM and required as the token aud claim. Must match the authorization server's configured resource URL (default: public-url + endpoint-path)")
+	_ = viper.BindPFlag("resource-url", httpCmd.Flags().Lookup("resource-url"))
 	_ = viper.BindPFlag("address", httpCmd.Flags().Lookup("address"))
 	_ = viper.BindPFlag("endpoint-path", httpCmd.Flags().Lookup("endpoint-path"))
 	_ = viper.BindPFlag("stateless", httpCmd.Flags().Lookup("stateless"))
@@ -138,6 +140,7 @@ func initConfig() {
 	_ = viper.BindEnv("stateless", "MCP_STATELESS")
 	_ = viper.BindEnv("public-url", "MCP_PUBLIC_URL")
 	_ = viper.BindEnv("authorization-server", "MCP_AUTHORIZATION_SERVER_URL")
+	_ = viper.BindEnv("resource-url", "MCP_RESOURCE_URL")
 
 	// Read config file if it exists
 	if err := viper.ReadInConfig(); err == nil {
@@ -216,6 +219,17 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 	if endpointPath == "/healthz" || endpointPath == "/.well-known" || strings.HasPrefix(endpointPath, "/.well-known/") {
 		return fmt.Errorf("configuration error: --endpoint-path %q collides with a reserved path (/healthz, /.well-known/...)", endpointPath)
 	}
+	// The identifier the AS binds tokens to (aud) and hosts send as resource=.
+	// Must match the AS's configured resource URL exactly, so an explicit
+	// value is used verbatim — validated, never rewritten.
+	resource := viper.GetString("resource-url")
+	if resource == "" {
+		resource = strings.TrimSuffix(publicURL+endpointPath, "/")
+	}
+	resourceURL, err := httptransport.ValidateResourceURL(resource)
+	if err != nil {
+		return fmt.Errorf("configuration error: %w", err)
+	}
 
 	logger := logging.SetupLogger(cfg.LogLevel)
 	logger.Info("Starting Honeybadger MCP Server",
@@ -225,6 +239,7 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 		"endpoint_path", endpointPath,
 		"stateless", stateless,
 		"public_url", publicURL,
+		"resource", resource,
 		"authorization_server", authServer,
 		"log_level", cfg.LogLevel,
 		"api_url", cfg.APIURL)
@@ -278,14 +293,17 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 	logger.Info("AS discovery complete", "issuer", md.Issuer, "jwks_uri", md.JWKSURI)
 
 	rootHandler := http.NewServeMux()
-	resource := publicURL + endpointPath
 	// Path-qualified per RFC 9728: PRM URL = /.well-known/oauth-protected-resource + resource path.
-	prmPath := httptransport.WellKnownPRMPath + endpointPath
+	prmPath := httptransport.WellKnownPRMPath + resourceURL.Path
 	prmAbsURL := publicURL + prmPath
-	handler := httptransport.PRMHandler(resource, []string{authServer})
-	rootHandler.Handle(prmPath, handler)
-	rootHandler.Handle(httptransport.WellKnownPRMPath, handler) // legacy origin-level path for clients that don't derive
-	rootHandler.Handle(endpointPath, httptransport.ValidateMiddleware(prmAbsURL, jwks.Keyfunc, md.Issuer, mcpHandler))
+	handler := httptransport.PRMHandler(resource, []string{authServer}, []string{"read", "write"})
+	// Origin-level path is the RFC 9728 location for a path-less resource and
+	// doubles as the legacy fallback for clients that don't derive the path.
+	if prmPath != httptransport.WellKnownPRMPath {
+		rootHandler.Handle(prmPath, handler)
+	}
+	rootHandler.Handle(httptransport.WellKnownPRMPath, handler)
+	rootHandler.Handle(endpointPath, httptransport.ValidateMiddleware(prmAbsURL, jwks.Keyfunc, md.Issuer, resource, mcpHandler))
 	rootHandler.HandleFunc("/healthz", httptransport.HealthHandler)
 	logger.Info("OAuth discovery enabled", "resource", resource, "prm_url", prmAbsURL)
 

--- a/internal/hbmcp/claims.go
+++ b/internal/hbmcp/claims.go
@@ -22,13 +22,12 @@ func (c *Claims) HasScope(scope string) bool {
 	return false
 }
 
-// No audience validation: the authorization server issues audience-less
-// tokens (no aud/resource claim, no RFC 8707 support), and their only
-// consumers are the Honeybadger API and this server, which relays each
-// token to that same API — so there is no second resource for a token to
-// be confused with. Revisit if the AS ever mints tokens for other
-// resources or signs other token types with the same key.
-func ParseAccessToken(raw string, keyfunc jwt.Keyfunc, expectedIssuer string) (*Claims, error) {
+// The AS audience-binds tokens per RFC 8707: hosts discover the resource
+// identifier from PRM and send it as resource= on the authorize and token
+// requests, and the AS mints it into aud. A missing or mismatched aud is
+// rejected (jwt.WithAudience treats absent aud as invalid) — without that
+// the binding does nothing.
+func ParseAccessToken(raw string, keyfunc jwt.Keyfunc, expectedIssuer, expectedAudience string) (*Claims, error) {
 	if !strings.HasPrefix(raw, tokenPrefix) {
 		return nil, errors.New("token missing hbo_ prefix")
 	}
@@ -38,6 +37,9 @@ func ParseAccessToken(raw string, keyfunc jwt.Keyfunc, expectedIssuer string) (*
 	}
 	if expectedIssuer != "" {
 		opts = append(opts, jwt.WithIssuer(expectedIssuer))
+	}
+	if expectedAudience != "" {
+		opts = append(opts, jwt.WithAudience(expectedAudience))
 	}
 	tok, err := jwt.NewParser(opts...).Parse(strings.TrimPrefix(raw, tokenPrefix), keyfunc)
 	if err != nil {

--- a/internal/hbmcp/claims_test.go
+++ b/internal/hbmcp/claims_test.go
@@ -41,7 +41,7 @@ func TestParseAccessToken_Success(t *testing.T) {
 	key, kf := testKey(t)
 	raw := signedToken(t, key, baseClaims())
 
-	got, err := ParseAccessToken(raw, kf, "http://localhost:3001")
+	got, err := ParseAccessToken(raw, kf, "http://localhost:3001", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestParseAccessToken_Success(t *testing.T) {
 func TestParseAccessToken_MissingPrefix(t *testing.T) {
 	key, kf := testKey(t)
 	signed, _ := jwt.NewWithClaims(jwt.SigningMethodRS256, baseClaims()).SignedString(key)
-	if _, err := ParseAccessToken(signed, kf, ""); err == nil {
+	if _, err := ParseAccessToken(signed, kf, "", ""); err == nil {
 		t.Fatal("expected error for missing prefix")
 	}
 }
@@ -67,7 +67,7 @@ func TestParseAccessToken_Expired(t *testing.T) {
 	c["exp"] = time.Now().Add(-time.Minute).Unix()
 	raw := signedToken(t, key, c)
 
-	_, err := ParseAccessToken(raw, kf, "")
+	_, err := ParseAccessToken(raw, kf, "", "")
 	if err == nil {
 		t.Fatal("expected expired error")
 	}
@@ -79,7 +79,7 @@ func TestParseAccessToken_Expired(t *testing.T) {
 func TestParseAccessToken_IssuerMismatch(t *testing.T) {
 	key, kf := testKey(t)
 	raw := signedToken(t, key, baseClaims())
-	if _, err := ParseAccessToken(raw, kf, "https://other.issuer"); err == nil {
+	if _, err := ParseAccessToken(raw, kf, "https://other.issuer", ""); err == nil {
 		t.Fatal("expected issuer mismatch")
 	}
 }
@@ -88,7 +88,7 @@ func TestParseAccessToken_BadSignature(t *testing.T) {
 	signer, _ := testKey(t)
 	_, verifierKF := testKey(t)
 	raw := signedToken(t, signer, baseClaims())
-	if _, err := ParseAccessToken(raw, verifierKF, ""); err == nil {
+	if _, err := ParseAccessToken(raw, verifierKF, "", ""); err == nil {
 		t.Fatal("expected signature error")
 	}
 }
@@ -98,7 +98,7 @@ func TestParseAccessToken_NoExp(t *testing.T) {
 	c := baseClaims()
 	delete(c, "exp")
 	raw := signedToken(t, key, c)
-	if _, err := ParseAccessToken(raw, kf, ""); err == nil {
+	if _, err := ParseAccessToken(raw, kf, "", ""); err == nil {
 		t.Fatal("expected error for missing exp")
 	}
 }
@@ -109,8 +109,43 @@ func TestParseAccessToken_WrongAlgorithm(t *testing.T) {
 	raw := tokenPrefix + signed
 
 	_, kf := testKey(t)
-	if _, err := ParseAccessToken(raw, kf, ""); err == nil {
+	if _, err := ParseAccessToken(raw, kf, "", ""); err == nil {
 		t.Fatal("expected rejection of HS256 token")
+	}
+}
+
+func TestParseAccessToken_AudienceMatch(t *testing.T) {
+	key, kf := testKey(t)
+	c := baseClaims()
+	c["aud"] = "https://mcp.honeybadger.io"
+	raw := signedToken(t, key, c)
+
+	if _, err := ParseAccessToken(raw, kf, "", "https://mcp.honeybadger.io"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAccessToken_AudienceMismatch(t *testing.T) {
+	key, kf := testKey(t)
+	c := baseClaims()
+	c["aud"] = "https://other.resource"
+	raw := signedToken(t, key, c)
+
+	_, err := ParseAccessToken(raw, kf, "", "https://mcp.honeybadger.io")
+	if err == nil {
+		t.Fatal("expected audience mismatch")
+	}
+	if !errors.Is(err, jwt.ErrTokenInvalidAudience) {
+		t.Errorf("error %v does not wrap jwt.ErrTokenInvalidAudience", err)
+	}
+}
+
+func TestParseAccessToken_MissingAudienceRejected(t *testing.T) {
+	key, kf := testKey(t)
+	raw := signedToken(t, key, baseClaims()) // no aud claim
+
+	if _, err := ParseAccessToken(raw, kf, "", "https://mcp.honeybadger.io"); err == nil {
+		t.Fatal("expected error for missing aud when an audience is expected")
 	}
 }
 
@@ -120,7 +155,7 @@ func TestParseAccessToken_EmptyScope(t *testing.T) {
 	c["scope"] = ""
 	raw := signedToken(t, key, c)
 
-	got, err := ParseAccessToken(raw, kf, "")
+	got, err := ParseAccessToken(raw, kf, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/httptransport/discovery.go
+++ b/internal/httptransport/discovery.go
@@ -34,6 +34,25 @@ func NormalizePublicURL(raw string) (string, error) {
 	return u.Scheme + "://" + u.Host, nil
 }
 
+// ValidateResourceURL checks a resource identifier per RFC 8707 §2: an
+// absolute URI with no fragment. The string is never rewritten — the AS
+// mints aud from its own canonical form of the same configured value, so
+// any transformation here risks a silent aud mismatch. The parsed URL is
+// returned for the RFC 9728 PRM path derivation.
+func ValidateResourceURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse resource-url: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("resource-url must include scheme and host, got %q", raw)
+	}
+	if u.Fragment != "" {
+		return nil, fmt.Errorf("resource-url must not include a fragment, got %q", raw)
+	}
+	return u, nil
+}
+
 // Leading slash: ServeMux panics without one. Trailing slash: PRM drift.
 func NormalizeEndpointPath(p string) string {
 	if p == "" {

--- a/internal/httptransport/discovery_test.go
+++ b/internal/httptransport/discovery_test.go
@@ -8,6 +8,41 @@ import (
 	"testing"
 )
 
+func TestValidateResourceURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantPath string
+		wantErr  bool
+	}{
+		{"origin only", "https://mcp.honeybadger.io", "", false},
+		{"path allowed", "https://mcp.honeybadger.io/mcp", "/mcp", false},
+		{"trailing slash preserved", "https://mcp.honeybadger.io/mcp/", "/mcp/", false},
+		{"query allowed (AS canonical form is authoritative)", "https://mcp.honeybadger.io/mcp?x=1", "/mcp", false},
+		{"fragment rejected", "https://mcp.honeybadger.io/mcp#frag", "", true},
+		{"missing scheme", "mcp.honeybadger.io", "", true},
+		{"missing host", "https://", "", true},
+		{"empty rejected", "", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			u, err := ValidateResourceURL(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", u)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if u.Path != c.wantPath {
+				t.Errorf("Path = %q, want %q", u.Path, c.wantPath)
+			}
+		})
+	}
+}
+
 func TestNormalizePublicURL(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/httptransport/middleware.go
+++ b/internal/httptransport/middleware.go
@@ -11,18 +11,19 @@ import (
 	"github.com/honeybadger-io/honeybadger-mcp-server/internal/hbmcp"
 )
 
-func PRMHandler(resource string, authServers []string) http.Handler {
+func PRMHandler(resource string, authServers, scopes []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"resource":              resource,
 			"authorization_servers": authServers,
+			"scopes_supported":      scopes,
 		})
 	})
 }
 
 // Expired tokens get an error_description so MCP clients trigger their refresh-on-401 path.
-func ValidateMiddleware(prmURL string, keyfn jwt.Keyfunc, expectedIssuer string, next http.Handler) http.Handler {
+func ValidateMiddleware(prmURL string, keyfn jwt.Keyfunc, expectedIssuer, expectedAudience string, next http.Handler) http.Handler {
 	bootstrap := fmt.Sprintf(`Bearer resource_metadata="%s"`, prmURL)
 	invalidToken := fmt.Sprintf(`Bearer error="invalid_token", resource_metadata="%s"`, prmURL)
 	expiredToken := fmt.Sprintf(`Bearer error="invalid_token", error_description="The access token expired", resource_metadata="%s"`, prmURL)
@@ -34,7 +35,7 @@ func ValidateMiddleware(prmURL string, keyfn jwt.Keyfunc, expectedIssuer string,
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		claims, err := hbmcp.ParseAccessToken(raw, keyfn, expectedIssuer)
+		claims, err := hbmcp.ParseAccessToken(raw, keyfn, expectedIssuer, expectedAudience)
 		if err != nil {
 			challenge := invalidToken
 			if errors.Is(err, jwt.ErrTokenExpired) {

--- a/internal/httptransport/middleware_test.go
+++ b/internal/httptransport/middleware_test.go
@@ -40,11 +40,12 @@ func validClaims() jwt.MapClaims {
 		"exp":        now + 60,
 		"scope":      "read write",
 		"account_id": float64(42),
+		"aud":        "https://host/mcp",
 	}
 }
 
 func TestPRMHandler(t *testing.T) {
-	h := PRMHandler("https://host/mcp", []string{"https://auth.example"})
+	h := PRMHandler("https://host/mcp", []string{"https://auth.example"}, []string{"read", "write"})
 
 	t.Run("GET returns metadata", func(t *testing.T) {
 		req := httptest.NewRequest("GET", WellKnownPRMPath, nil)
@@ -60,6 +61,7 @@ func TestPRMHandler(t *testing.T) {
 		var got struct {
 			Resource             string   `json:"resource"`
 			AuthorizationServers []string `json:"authorization_servers"`
+			ScopesSupported      []string `json:"scopes_supported"`
 		}
 		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 			t.Fatalf("body unmarshal: %v", err)
@@ -69,6 +71,9 @@ func TestPRMHandler(t *testing.T) {
 		}
 		if len(got.AuthorizationServers) != 1 || got.AuthorizationServers[0] != "https://auth.example" {
 			t.Errorf("authorization_servers = %v", got.AuthorizationServers)
+		}
+		if len(got.ScopesSupported) != 2 || got.ScopesSupported[0] != "read" || got.ScopesSupported[1] != "write" {
+			t.Errorf("scopes_supported = %v", got.ScopesSupported)
 		}
 	})
 
@@ -83,10 +88,13 @@ func TestValidateMiddleware(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	mw := ValidateMiddleware(prmURL, kf, "https://issuer.example", next)
+	mw := ValidateMiddleware(prmURL, kf, "https://issuer.example", "https://host/mcp", next)
 
 	expiredClaims := validClaims()
 	expiredClaims["exp"] = time.Now().Add(-time.Minute).Unix()
+
+	wrongAudClaims := validClaims()
+	wrongAudClaims["aud"] = "https://other.resource"
 
 	cases := []struct {
 		name            string
@@ -114,6 +122,12 @@ func TestValidateMiddleware(t *testing.T) {
 			header:         "Bearer " + signHBO(t, key, expiredClaims),
 			wantStatus:     http.StatusUnauthorized,
 			wantAuthSubstr: `error_description="The access token expired"`,
+		},
+		{
+			name:           "wrong audience → invalid_token",
+			header:         "Bearer " + signHBO(t, key, wrongAudClaims),
+			wantStatus:     http.StatusUnauthorized,
+			wantAuthSubstr: `error="invalid_token"`,
 		},
 		{
 			name:           "valid → passes through",


### PR DESCRIPTION
The AS now audience-binds tokens per RFC 8707: hosts send resource= on the authorize and token requests and the AS mints it into aud. Enforce that binding by rejecting tokens with a missing or mismatched aud.

- New --resource-url flag / MCP_RESOURCE_URL env names the resource identifier; it must match the AS's configured value exactly, so it is validated (absolute URI, no fragment) but never rewritten. Defaults to public-url + endpoint-path.
- PRM advertises scopes_supported [read, write] and the PRM route is derived from the resource path per RFC 9728.