### PR TITLE
Build, test, and release images from version tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,9 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Tag pushes and manual dispatches have no workflow_run payload; only
+    # gate on Test's conclusion when Test is what triggered us.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -70,3 +72,25 @@ jobs:
         package-type: container
         min-versions-to-keep: 10
       continue-on-error: true
+
+  # Gated on the image push so the Releases page only ever lists versions
+  # with a pullable image behind them — it's the signal for what can be
+  # pinned in the ops repo's task definition.
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
+
+    steps:
+    # Notes are generated from merged PRs since the previous release. The
+    # view-first guard makes tag re-pushes and workflow re-runs no-ops
+    # instead of failures, and never overwrites hand-edited notes.
+    - name: Create release with generated notes
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 ||
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --generate-notes --verify-tag

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,12 +15,24 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Tag pushes never run the Test workflow on their own (it only watches
+  # main), so invoke it against the tagged commit before publishing its
+  # image — "release only green main commits" becomes enforced, not
+  # convention.
+  test:
+    name: Test tagged commit
+    if: ${{ github.ref_type == 'tag' }}
+    uses: ./.github/workflows/test.yml
+
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    needs: [test]
     # Tag pushes and manual dispatches have no workflow_run payload; only
-    # gate on Test's conclusion when Test is what triggered us.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # gate on Test's conclusion when Test is what triggered us. The test
+    # job above only runs for tags, so its skip must not block the other
+    # triggers (hence !cancelled() instead of the implicit success()).
+    if: ${{ !cancelled() && (needs.test.result == 'success' || needs.test.result == 'skipped') && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') }}
     permissions:
       contents: read
       packages: write
@@ -28,6 +40,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        # A workflow_run fires against the default branch tip, which may
+        # have moved past the tested commit; build exactly what Test ran.
+        # Empty ref falls through to the default for the other triggers.
+        ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -44,12 +61,18 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        # semver {{raw}} keeps the v prefix so image tag v1.2.3 matches the
+        # GitHub Release name exactly; the ops repo can pin either form.
+        # The sha tag is computed from the same expression as the checkout
+        # ref above — the event context sha points at the branch tip on
+        # workflow_run, which may not be the commit being built.
         tags: |
           type=ref,event=branch
           type=ref,event=pr
+          type=semver,pattern={{raw}}
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=sha,format=long,prefix=
+          type=raw,value=${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
@@ -65,12 +88,16 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+    # Releases are the ledger of pinnable versions, so retention must far
+    # outlast the release cadence — a deleted semver image would leave a
+    # Release pointing at nothing. (Tag-protection rules would be exact,
+    # but untagged multi-arch child manifests make that fragile here.)
     - name: Delete old images
       uses: actions/delete-package-versions@v5
       with:
         package-name: honeybadger-mcp-server
         package-type: container
-        min-versions-to-keep: 10
+        min-versions-to-keep: 100
       continue-on-error: true
 
   # Gated on the image push so the Releases page only ever lists versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Lets other workflows (docker-build's tag path) run the suite as a job
+  # instead of duplicating these steps.
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
## What this changes

Pushing a `v*` tag previously did nothing: the Docker workflow declared a tag trigger, but its job-level `if` only ever passed for `workflow_run`-triggered runs, so tag builds were silently skipped. With deploys now done by hand via Terraform after tagging, the tag becomes the release trigger, with a guarantee chain behind it:

1. **The full test suite runs against the exact tagged commit** (reusing `test.yml` via `workflow_call` — no duplicated steps). A failing commit produces no artifacts.
2. **A multi-arch image is built from that commit** and pushed to ghcr as `v1.2.3`, `1.2.3`, `1.2`, and the commit sha, with the version baked into the binary via ldflags.
3. **A GitHub Release is created with generated notes** — only after the image push succeeds.

## Why it helps deployment

- **The Releases page becomes a trustworthy pick-list**: a Release existing means a tested, pullable image exists. The tag name works verbatim as the image tag to pin in the ops repo's task definition (the `v`-prefixed image tag is published alongside the bare semver forms).
- **Deploys ride pinned versions, not `:latest`** — main merges still move `latest`, but releases are immutable. Rollback is repinning the previous tag.
- **Untested releases are impossible, not just unconventional** — tagging the wrong commit or a side branch runs the suite against it anyway.
- **Nothing deploys automatically** — CI ends at "artifact exists and is proven good"; when and where to deploy lives in Terraform.

## Additional fixes from review

- `workflow_run` builds now check out and sha-tag `workflow_run.head_sha` — the default checkout follows the main tip, which can move past the commit Test actually validated, and the image label must match the built content.
- Package retention raised from 10 to 100 versions so release images aren't garbage-collected while a Release still points at them (tag-protection alternatives are fragile with multi-arch child manifests).
- The Release job is idempotent: re-runs and tag re-pushes are no-ops, and hand-edited release notes are never overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)