### PR TITLE
Make account_id optional when creating projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ read-only: true
   - `id` : The ID of the project to retrieve (number, required)
 
 - **create_project** - Create a new Honeybadger project _(requires `read-only=false`)_
-  - `account_id` : The account ID to associate the project with (string, required)
+  - `account_id` : The account ID to associate the project with. If omitted, the project is created in the first account your auth token has access to (string, optional)
   - `name` : The name of the new project (string, required)
   - `resolve_errors_on_deploy` : Whether all unresolved faults should be marked as resolved when a deploy is recorded (boolean, optional)
   - `disable_public_links` : Whether to allow fault details to be publicly shareable via a button on the fault detail page (boolean, optional)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/honeybadger-io/api-go v0.6.0
+	github.com/honeybadger-io/api-go v0.6.1
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/honeybadger-io/api-go v0.6.0 h1:wgAU+hReTyaXM7EsR3SaWZC9kXLmt9ato3TX+9r6F+I=
-github.com/honeybadger-io/api-go v0.6.0/go.mod h1:VurinfWN9qR1Bd9Zju2pIDgG1vIi5Qq3GpcsfToQiBU=
+github.com/honeybadger-io/api-go v0.6.1 h1:t+NWXAx0cn8vO2ojw5cXpoA69820fPS5MZstuiBAPHQ=
+github.com/honeybadger-io/api-go v0.6.1/go.mod h1:VurinfWN9qR1Bd9Zju2pIDgG1vIi5Qq3GpcsfToQiBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/hbmcp/projects.go
+++ b/internal/hbmcp/projects.go
@@ -51,8 +51,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
 			mcp.WithString("account_id",
-				mcp.Required(),
-				mcp.Description("The account ID to associate the project with"),
+				mcp.Description("The account ID to associate the project with. If omitted, the project is created in the first account your auth token has access to."),
 				mcp.MinLength(1),
 			),
 			mcp.WithString("name",
@@ -301,10 +300,9 @@ func handleGetProject(ctx context.Context, client *hbapi.Client, req mcp.CallToo
 }
 
 func handleCreateProject(ctx context.Context, client *hbapi.Client, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Optional: the API associates the project with the token's first
+	// accessible account when account_id is absent.
 	accountID := req.GetString("account_id", "")
-	if accountID == "" {
-		return mcp.NewToolResultError("account_id is required"), nil
-	}
 
 	// Build project request using typed getters
 	projectReq := hbapi.ProjectRequest{

--- a/internal/hbmcp/projects_test.go
+++ b/internal/hbmcp/projects_test.go
@@ -512,9 +512,21 @@ func TestHandleCreateProject_ValidationError(t *testing.T) {
 	}
 }
 
-func TestHandleCreateProject_MissingAccountID(t *testing.T) {
+func TestHandleCreateProject_WithoutAccountID(t *testing.T) {
+	mockResponse := `{"id": 456, "name": "Test Project", "active": true, "created_at": "2024-01-01T00:00:00Z", "token": "secret789", "fault_count": 0, "unresolved_fault_count": 0, "environments": [], "owner": {"id": 1, "email": "user@example.com", "name": "User 1"}, "sites": [], "teams": [], "users": []}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("account_id") {
+			t.Errorf("expected no account_id query param, got raw query %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
 	client := hbapi.NewClient().
-		WithBaseURL("https://api.example.com").
+		WithBaseURL(server.URL).
 		WithAuthToken("test-token")
 
 	req := mcp.CallToolRequest{
@@ -530,12 +542,16 @@ func TestHandleCreateProject_MissingAccountID(t *testing.T) {
 		t.Fatalf("handleCreateProject() error = %v", err)
 	}
 
-	if !result.IsError {
-		t.Fatal("expected error result for missing account_id")
+	if result.IsError {
+		t.Fatalf("expected success without account_id, got error: %s", getResultText(result))
 	}
 
-	if !strings.Contains(getResultText(result), "account_id is required") {
-		t.Error("Error message should indicate missing account_id parameter")
+	var project hbapi.Project
+	if err := json.Unmarshal([]byte(getResultText(result)), &project); err != nil {
+		t.Errorf("Response should be valid JSON project: %v", err)
+	}
+	if project.ID != 456 {
+		t.Errorf("expected project ID 456, got %d", project.ID)
 	}
 }
 


### PR DESCRIPTION
When account_id is omitted, the API associates the project with the first account the auth token has access to, so the tool no longer requires it. The test asserts the query parameter is genuinely absent — not blank — which is what triggers the API's default-account behavior; that guarantee comes from the paired api-go change (Create omits the parameter when the account ID is empty) and needs an api-go release and go.mod bump before this branch merges.