### PR TITLE
Landing page & other tweaks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,11 +66,14 @@ jobs:
         # The sha tag is computed from the same expression as the checkout
         # ref above — the event context sha points at the branch tip on
         # workflow_run, which may not be the commit being built.
+        # {{version}} stays listed before {{raw}}: the first entry decides
+        # the action's `version` output, which feeds the VERSION build-arg
+        # and must be the bare semver, not the v-prefixed tag name.
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{raw}}
           type=semver,pattern={{version}}
+          type=semver,pattern={{raw}}
           type=semver,pattern={{major}}.{{minor}}
           type=raw,value=${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           type=raw,value=latest,enable={{is_default_branch}}

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,21 @@
+# Local-development image that builds against a local api-go checkout
+# instead of the go.mod release. Never used for production builds — the
+# release pipeline uses Dockerfile.
+#
+# Usage (the apigo build context is required):
+#   docker buildx build -f Dockerfile.local --build-context apigo=../api-go \
+#     -t honeybadger-mcp-server:local --load .
+FROM golang:1.25.5-alpine AS build
+WORKDIR /build
+COPY . .
+COPY --from=apigo / /apigo
+ARG VERSION=dev-local
+RUN go mod edit -replace github.com/honeybadger-io/api-go=/apigo && \
+    CGO_ENABLED=0 go build -ldflags "-X main.version=${VERSION}" -o /bin/honeybadger-mcp-server ./cmd/honeybadger-mcp-server
+
+FROM alpine:3
+WORKDIR /server
+EXPOSE 8080
+COPY --from=build /bin/honeybadger-mcp-server .
+ENTRYPOINT ["/server/honeybadger-mcp-server"]
+CMD ["stdio"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ APIGO_DIR ?= ../api-go
 .PHONY: build test docker docker-local
 
 build:
-	go build ./...
+	go build -o honeybadger-mcp-server ./cmd/honeybadger-mcp-server
 
 test:
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+IMAGE     ?= honeybadger-mcp-server
+TAG       ?= hosted-test
+APIGO_DIR ?= ../api-go
+
+.PHONY: build test docker docker-local
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+# Image with release dependencies, as the production pipeline builds it.
+docker:
+	docker build -t $(IMAGE):$(TAG) .
+
+# Image built against the local api-go checkout (whatever branch it has
+# checked out) instead of the go.mod release.
+docker-local:
+	docker buildx build -f Dockerfile.local --build-context apigo=$(APIGO_DIR) \
+		-t $(IMAGE):$(TAG) --load .

--- a/cmd/honeybadger-mcp-server/main.go
+++ b/cmd/honeybadger-mcp-server/main.go
@@ -308,6 +308,7 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 	rootHandler.HandleFunc("/healthz", httptransport.HealthHandler)
 	landing, err := httptransport.NewLandingHandler(httptransport.LandingData{
 		MCPURL:  resource,
+		AppURL:  authServer,
 		Version: version,
 		Tools:   toolCatalog,
 	})
@@ -372,6 +373,9 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 }
 
 func main() {
+	// The build may inject either 1.0.0 or the raw v1.0.0 tag name;
+	// normalize so displays that prepend "v" don't render "vv1.0.0".
+	version = strings.TrimPrefix(version, "v")
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/internal/httptransport/landing.go
+++ b/internal/httptransport/landing.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/honeybadger-io/honeybadger-mcp-server/internal/hbmcp"
 )
@@ -15,8 +16,21 @@ var landingTemplate string
 
 type LandingData struct {
 	MCPURL  string
+	// Region-specific app origin for the sign-in link (the authorization
+	// server: app.honeybadger.io in US, eu-app.honeybadger.io in EU).
+	AppURL  string
 	Version string
 	Tools   []hbmcp.ToolInfo
+}
+
+// Tool descriptions are written for LLM consumption — after the first
+// sentence they carry agent guidance ("IMPORTANT: call X first…") that
+// reads as noise to people. Show only the human-meaningful summary.
+func firstSentence(s string) string {
+	if i := strings.Index(s, ". "); i >= 0 {
+		return s[:i+1]
+	}
+	return s
 }
 
 // NewLandingHandler serves a static informational page at "/" describing the
@@ -27,6 +41,12 @@ func NewLandingHandler(data LandingData) (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	tools := make([]hbmcp.ToolInfo, len(data.Tools))
+	for i, t := range data.Tools {
+		t.Description = firstSentence(t.Description)
+		tools[i] = t
+	}
+	data.Tools = tools
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
 		return nil, err

--- a/internal/httptransport/landing.go
+++ b/internal/httptransport/landing.go
@@ -15,7 +15,7 @@ import (
 var landingTemplate string
 
 type LandingData struct {
-	MCPURL  string
+	MCPURL string
 	// Region-specific app origin for the sign-in link (the authorization
 	// server: app.honeybadger.io in US, eu-app.honeybadger.io in EU).
 	AppURL  string

--- a/internal/httptransport/landing.html.tmpl
+++ b/internal/httptransport/landing.html.tmpl
@@ -112,7 +112,9 @@
   code { font-family: var(--mono); }
   .codeblock { position: relative; }
   .codeblock button.copy {
-    position: absolute; top: 0.55rem; right: 0.55rem;
+    /* Vertically centers the button in a single-line block (~3.5rem tall);
+       multi-line blocks keep it comfortably top-anchored. */
+    position: absolute; top: 1rem; right: 0.55rem;
     background: #333333; color: #d4d4d4;
     border: 1px solid rgba(255,255,255,0.15); border-radius: 0.4rem;
     font: 600 0.72rem var(--sans); padding: 0.28rem 0.6rem; cursor: pointer;
@@ -167,7 +169,7 @@
     <nav class="site-nav">
       <a href="https://docs.honeybadger.io/resources/llms/">Docs</a>
       <a href="https://github.com/honeybadger-io/honeybadger-mcp-server">GitHub</a>
-      <a href="https://app.honeybadger.io">Sign in</a>
+      <a href="{{.AppURL}}">Sign in</a>
     </nav>
   </div>
 </header>
@@ -189,7 +191,7 @@
       Streamable HTTP with OAuth &mdash; your client opens a browser window to
       sign in to Honeybadger. No API keys to copy around.
     </p>
-    <div class="card endpoint">
+    <div class="endpoint">
       <div class="codeblock">
         <pre><code>{{.MCPURL}}</code></pre>
         <button class="copy" type="button">Copy</button>

--- a/internal/httptransport/landing_test.go
+++ b/internal/httptransport/landing_test.go
@@ -12,11 +12,13 @@ import (
 func testLandingHandler(t *testing.T) http.Handler {
 	t.Helper()
 	h, err := NewLandingHandler(LandingData{
-		MCPURL:  "https://mcp.honeybadger.io/mcp",
+		MCPURL:  "https://eu-mcp.honeybadger.io/mcp",
+		AppURL:  "https://eu-app.honeybadger.io",
 		Version: "1.2.3",
 		Tools: []hbmcp.ToolInfo{
 			{Name: "list_projects", Description: "List all projects", ReadOnly: true},
 			{Name: "create_project", Description: "Create a new project", ReadOnly: false},
+			{Name: "create_alarm", Description: "Create a new Insights alarm. IMPORTANT: Call get_insights_reference first for full alarm documentation.", ReadOnly: false},
 		},
 	})
 	if err != nil {
@@ -41,7 +43,8 @@ func TestLandingHandler_ServesRootHTML(t *testing.T) {
 
 	body := rec.Body.String()
 	for _, want := range []string{
-		"https://mcp.honeybadger.io/mcp",
+		"https://eu-mcp.honeybadger.io/mcp",
+		`href="https://eu-app.honeybadger.io"`,
 		"list_projects",
 		"List all projects",
 		"create_project",
@@ -50,6 +53,14 @@ func TestLandingHandler_ServesRootHTML(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
 		}
+	}
+
+	// Agent-facing guidance after the first sentence must not reach the page.
+	if !strings.Contains(body, "Create a new Insights alarm.") {
+		t.Error("body missing first sentence of create_alarm description")
+	}
+	if strings.Contains(body, "IMPORTANT") {
+		t.Error("body leaks agent guidance past the first sentence")
 	}
 }
 


### PR DESCRIPTION
- Fixed the Docker build so the version baked into the binary is the plain version number (1.0.0) instead of the tag name (v1.0.0). The server also strips a leading "v" at startup, so version displays can never show "vv1.0.0".
- The landing page's "Sign in" link now points to the right region — EU visitors are sent to eu-app.honeybadger.io instead of always going to app.honeybadger.io.
- Tool descriptions on the landing page now show just their first sentence. The full descriptions include instructions written for AI agents ("IMPORTANT: call get_insights_reference first..."), which read as clutter to people.
- Centered the "Copy" button on the endpoint URL box and removed its doubled-up card styling.
- Added a Makefile with shortcuts for building, testing, and building Docker images.
- Added Dockerfile.local, which builds the server against a local api-go checkout instead of the released version — handy for testing api-go changes before they're published.