### PR TITLE
deprecated `get_insights_reference` alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,40 @@
 IMAGE     ?= honeybadger-mcp-server
 TAG       ?= hosted-test
 APIGO_DIR ?= ../api-go
+# Default to prod; override HONEYBADGER_URL / DOCS_URL in the environment
+# (e.g. via .envrc) to point docker-run at local services.
+HONEYBADGER_URL ?= https://app.honeybadger.io
+DOCS_URL        ?= https://docs.honeybadger.io
+MCP_NAME       ?= honeybadger-dev
+MCP_PORT       ?= 9090
+MCP_PUBLIC_URL ?= http://localhost:$(MCP_PORT)
+MCP_URL        ?= $(MCP_PUBLIC_URL)/mcp
 
-.PHONY: build test docker docker-local
+.PHONY: build test docker docker-local docker-run mcp-add mcp-remove
 
 build:
 	go build -o honeybadger-mcp-server ./cmd/honeybadger-mcp-server
 
 test:
 	go test ./...
+
+docker-run:
+	docker run --rm --network=host \
+		-e HONEYBADGER_API_URL=$(HONEYBADGER_URL) \
+		-e HONEYBADGER_INSTRUCTIONS_URL=$(DOCS_URL)/resources/llms/instructions \
+		-e MCP_ADDRESS=:$(MCP_PORT) \
+		-e MCP_PUBLIC_URL=$(MCP_PUBLIC_URL) \
+		-e MCP_AUTHORIZATION_SERVER_URL=$(HONEYBADGER_URL) \
+		-e LOG_LEVEL=debug \
+		$(IMAGE):$(TAG) http
+
+# Register the locally-running http host with Claude Code (uses OAuth against
+# whatever MCP_AUTHORIZATION_SERVER_URL the container was started with).
+claude-mcp-add:
+	claude mcp add --transport http $(MCP_NAME) $(MCP_URL)
+
+claude-mcp-remove:
+	claude mcp remove $(MCP_NAME)
 
 # Image with release dependencies, as the production pipeline builds it.
 docker:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MCP_PORT       ?= 9090
 MCP_PUBLIC_URL ?= http://localhost:$(MCP_PORT)
 MCP_URL        ?= $(MCP_PUBLIC_URL)/mcp
 
-.PHONY: build test docker docker-local docker-run mcp-add mcp-remove
+.PHONY: build test docker docker-local docker-run claude-mcp-add claude-mcp-remove
 
 build:
 	go build -o honeybadger-mcp-server ./cmd/honeybadger-mcp-server

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -34,7 +34,7 @@ func TestListTools(t *testing.T) {
 		t.Fatalf("Failed to list tools: %v", err)
 	}
 
-	expectedToolCount := 32 // create_alarm, create_check_in, create_dashboard, create_project, delete_alarm, delete_check_in, delete_dashboard, delete_project, get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools, update_alarm, update_check_in, update_dashboard, update_project
+	expectedToolCount := 33 // create_alarm, create_check_in, create_dashboard, create_project, delete_alarm, delete_check_in, delete_dashboard, delete_project, get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_insights_reference, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools, update_alarm, update_check_in, update_dashboard, update_project
 	if len(tools) != expectedToolCount {
 		t.Errorf("Expected %d tools, got %d", expectedToolCount, len(tools))
 	}
@@ -57,7 +57,7 @@ func TestListTools(t *testing.T) {
 	}
 
 	// Verify all expected tools are present
-	expectedTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools", "update_alarm", "update_check_in", "update_dashboard", "update_project"}
+	expectedTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_insights_reference", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools", "update_alarm", "update_check_in", "update_dashboard", "update_project"}
 	for _, expectedTool := range expectedTools {
 		found := false
 		for _, foundTool := range foundTools {
@@ -94,7 +94,7 @@ func TestListToolsReadOnly(t *testing.T) {
 		t.Fatalf("Failed to list tools: %v", err)
 	}
 
-	expectedToolCount := 20 // get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools
+	expectedToolCount := 21 // get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_insights_reference, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools
 	if len(tools) != expectedToolCount {
 		t.Errorf("Expected %d tools in read-only mode, got %d", expectedToolCount, len(tools))
 	}
@@ -112,7 +112,7 @@ func TestListToolsReadOnly(t *testing.T) {
 	}
 
 	// Verify only read-only tools are present
-	expectedReadOnlyTools := []string{"get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools"}
+	expectedReadOnlyTools := []string{"get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_insights_reference", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools"}
 	for _, expectedTool := range expectedReadOnlyTools {
 		found := false
 		for _, foundTool := range foundTools {

--- a/internal/hbmcp/reference.go
+++ b/internal/hbmcp/reference.go
@@ -181,7 +181,40 @@ func RegisterReferenceTools(r *toolRegistrar, fetcher *referenceFetcher) {
 			return handleGetReference(ctx, fetcher, req)
 		},
 	)
+
+	// Deprecated alias: get_reference was previously named get_insights_reference.
+	// Registered hidden so it stays reachable for clients whose cached tool list
+	// still has the old name, without advertising it to fresh clients via
+	// search_tools or the landing page. It deliberately returns no reference
+	// content: its only job is to report that the tool list is stale and must be
+	// refreshed. The alias is retained for all v1.x releases; earliest removal is
+	// v2.0.
+	r.AddHiddenTool(
+		mcp.NewTool("get_insights_reference",
+			mcp.WithDescription("Deprecated and non-functional: renamed to get_reference. Returns no content; calling it only reports that the client's tool list is out of date. Use get_reference instead."),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		handleDeprecatedInsightsReference,
+	)
 }
+
+// handleDeprecatedInsightsReference is the handler for the old
+// get_insights_reference name. It returns no reference content — reaching it at
+// all means the caller's tool list is stale — so it reports that as an error
+// result carrying instructions to refresh and switch to get_reference.
+func handleDeprecatedInsightsReference(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultError(deprecatedReferenceNotice), nil
+}
+
+// deprecatedReferenceNotice is the entire payload returned for the old
+// get_insights_reference name. It must be self-contained: it reaches clients
+// whose cached tool list is stale (the description they see is stale too), so it
+// carries the full instruction to refresh.
+const deprecatedReferenceNotice = "`get_insights_reference` has been renamed to `get_reference` and no longer returns content. " +
+	"Reaching this tool means the MCP client's cached tool list is out of date, so other tool names, descriptions, and " +
+	"input schemas may be stale too. Tell the user to reconnect the Honeybadger MCP server (for example, run `/mcp` and " +
+	"reconnect, or restart the client) to refresh tool definitions, then call `get_reference` for reference content."
 
 func handleGetReference(ctx context.Context, f *referenceFetcher, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	idx, err := f.index(ctx)

--- a/internal/hbmcp/reference.go
+++ b/internal/hbmcp/reference.go
@@ -283,7 +283,7 @@ func renderIndex(idx *instructionIndex) string {
 // client-side skills, not the server.
 func ServerInstructions() string {
 	var sb strings.Builder
-	sb.WriteString("Honeybadger provides error tracking, uptime monitoring, and Insights (log/event analytics queried with BadgerQL).\n\n")
+	sb.WriteString("Honeybadger provides error tracking, uptime and check-in (cron/scheduled task) monitoring, and Insights (log/event analytics queried with BadgerQL).\n\n")
 	sb.WriteString("Reference documentation is split into non-overlapping topics served by the get_reference tool: ")
 	sb.WriteString(strings.Join(referenceTopicNames, ", "))
 	sb.WriteString(". Tool descriptions state which topics they require. Fetch required topics in a single get_reference call before using those tools, and never re-fetch a topic whose content is still visible in your context. Call get_reference with no arguments for the topic index.\n\n")

--- a/internal/hbmcp/reference_test.go
+++ b/internal/hbmcp/reference_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 var testSets = []struct {
@@ -154,6 +155,47 @@ func TestHandleGetReference_All(t *testing.T) {
 	for _, s := range testSets {
 		if !strings.Contains(resultText, s.content) {
 			t.Errorf("\"all\" should include full content of topic %q", s.name)
+		}
+	}
+}
+
+func TestHandleDeprecatedInsightsReference_ReportsRenameAsError(t *testing.T) {
+	// The alias needs no docs server: it never fetches content, it only reports
+	// that the caller's tool list is stale.
+	result, err := handleDeprecatedInsightsReference(context.Background(), referenceRequest("all"))
+	if err != nil {
+		t.Fatalf("handleDeprecatedInsightsReference() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("alias should return an error result so the client treats the call as failed")
+	}
+
+	resultText := getResultText(result)
+	if !strings.Contains(resultText, "get_reference") {
+		t.Error("notice should point callers at get_reference")
+	}
+	if !strings.Contains(resultText, "reconnect") {
+		t.Error("notice should instruct the user to reconnect")
+	}
+	// The alias must not serve reference content — reaching it means the tool
+	// list is stale, and it exists only to say so.
+	for _, s := range testSets {
+		if strings.Contains(resultText, s.content) {
+			t.Errorf("alias must not return reference content, but included topic %q", s.name)
+		}
+	}
+}
+
+func TestDeprecatedAliasHiddenFromCatalog(t *testing.T) {
+	// The alias must stay out of search_tools / landing so fresh clients don't
+	// discover and adopt the deprecated name.
+	s := server.NewMCPServer("test", "0.0.0")
+	r := newToolRegistrar(s)
+	RegisterReferenceTools(r, testFetcher("http://example.invalid"))
+
+	for _, ti := range r.catalog {
+		if ti.Name == "get_insights_reference" {
+			t.Error("deprecated alias should not appear in the searchable catalog")
 		}
 	}
 }

--- a/internal/hbmcp/tool_search.go
+++ b/internal/hbmcp/tool_search.go
@@ -36,6 +36,16 @@ func (r *toolRegistrar) AddTool(tool mcp.Tool, handler server.ToolHandlerFunc) {
 	})
 }
 
+// AddHiddenTool registers a callable tool that is omitted from the searchable
+// catalog and the landing-page listing. It is used for deprecated aliases that
+// must stay reachable for clients whose cached tool list still names them,
+// without inviting fresh clients to discover and adopt them. The tool still
+// appears in tools/list (mcp-go has no way to route a handler otherwise), so its
+// description must make its deprecated status self-evident.
+func (r *toolRegistrar) AddHiddenTool(tool mcp.Tool, handler server.ToolHandlerFunc) {
+	r.server.AddTool(tool, handler)
+}
+
 func searchCatalog(catalog []ToolInfo, query string) []ToolInfo {
 	q := strings.ToLower(query)
 	var results []ToolInfo


### PR DESCRIPTION
Add hidden get_insights_reference alias for the rename

### What

The Insights reference tool was renamed get_insights_reference → get_reference (it now serves topic-split docs — badgerql, queries, charts, dashboards, alarms, errors — not just Insights). This branch adds a backward-compatibility alias for the old name so clients that still call it don't hard-fail.

The alias is registered hidden (AddHiddenTool): it stays reachable via tools/call, but is excluded from the searchable search_tools catalog and the landing-page listing, so fresh clients never discover or adopt the dead name. It returns no reference content — only a notice that the client's cached tool list is stale and should be refreshed (reconnect / restart), then to use get_reference.

Deprecation contract: alias retained through all v1.x releases; v2.0 is the earliest removal point.

### Why

MCP clients cache tools/list metadata (names, descriptions, schemas). When we rename a tool and redeploy, clients holding a stale list keep calling the old name. The mechanisms that would auto-refresh them don't cover a redeploy:

- notifications/tools/list_changed can't span a redeploy — the connection drops, so there's no live session to notify.
- TTL / reconnect-refresh only bound staleness and depend on client cooperation we don't control (headless CI/PR bots especially).

So a bare rename silently breaks callers we don't own. The alias is the only mechanism that needs nothing from the client: the old name keeps resolving. We deliberately make it error-and-teach rather than silently forward, because the reference content is fetched live anyway — the right fix for a stale client is to refresh its whole tool list, not just paper over one call. The notice carries that instruction in the result, where it can't go stale.

I also added some makefile updates to simplify bootstrapping testing