### PR TITLE
Add title annotations to all MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Contributor notes
+
+## Adding a new MCP tool
+
+Every tool registered with the server must declare, in this order inside
+`mcp.NewTool(...)`:
+
+1. `mcp.WithTitleAnnotation("Title Case Name")` — a short, human-readable title.
+   Required by the Anthropic Connectors Directory; a missing title is an
+   automatic review rejection.
+2. `mcp.WithDescription(...)` — what the tool does.
+3. `mcp.WithReadOnlyHintAnnotation(...)` and `mcp.WithDestructiveHintAnnotation(...)`
+   — both are required on every tool. Read-only tools: `ReadOnly(true)` /
+   `Destructive(false)`. Tools that create, update, or delete: `ReadOnly(false)`
+   / `Destructive(true)`.
+
+`TestAllToolsHaveTitleAndAnnotations` in `internal/hbmcp/server_test.go` fails
+the build if any tool (including hidden aliases) is missing a title,
+`readOnlyHint`, or `destructiveHint`. Run `go test ./...` before committing.
+
+Tools live in `internal/hbmcp/` grouped by domain (`faults.go`, `alarms.go`,
+`projects.go`, `dashboards.go`, `checkins.go`, `insights.go`, `reference.go`)
+and are registered from `internal/hbmcp/server.go`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,10 @@ Every tool registered with the server must declare, in this order inside
    automatic review rejection.
 2. `mcp.WithDescription(...)` — what the tool does.
 3. `mcp.WithReadOnlyHintAnnotation(...)` and `mcp.WithDestructiveHintAnnotation(...)`
-   — both are required on every tool. Read-only tools: `ReadOnly(true)` /
-   `Destructive(false)`. Tools that create, update, or delete: `ReadOnly(false)`
-   / `Destructive(true)`.
+   — both are required on every tool. Read-only tools:
+   `mcp.WithReadOnlyHintAnnotation(true)` / `mcp.WithDestructiveHintAnnotation(false)`.
+   Tools that create, update, or delete:
+   `mcp.WithReadOnlyHintAnnotation(false)` / `mcp.WithDestructiveHintAnnotation(true)`.
 
 `TestAllToolsHaveTitleAndAnnotations` in `internal/hbmcp/server_test.go` fails
 the build if any tool (including hidden aliases) is missing a title,

--- a/internal/hbmcp/alarms.go
+++ b/internal/hbmcp/alarms.go
@@ -14,6 +14,7 @@ func RegisterAlarmTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_alarms tool
 	r.AddTool(
 		mcp.NewTool("list_alarms",
+			mcp.WithTitleAnnotation("List Alarms"),
 			mcp.WithDescription("List all Insights alarms for a Honeybadger project. To interpret alarm configuration, fetch reference topic: alarms (via get_reference)."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -31,6 +32,7 @@ func RegisterAlarmTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_alarm tool
 	r.AddTool(
 		mcp.NewTool("get_alarm",
+			mcp.WithTitleAnnotation("Get Alarm"),
 			mcp.WithDescription("Get a single Insights alarm by ID. To interpret alarm configuration, fetch reference topic: alarms (via get_reference)."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -52,6 +54,7 @@ func RegisterAlarmTools(r *toolRegistrar, clientFor ClientFactory) {
 	// create_alarm tool
 	r.AddTool(
 		mcp.NewTool("create_alarm",
+			mcp.WithTitleAnnotation("Create Alarm"),
 			mcp.WithDescription("Create a new Insights alarm for a Honeybadger project. IMPORTANT: Requires reference topics: alarms, queries, badgerql — fetch via get_reference first (skip topics still visible in your context) for the trigger_config schema and query guidelines. Verify the query returns the expected results via query_insights before creating the alarm."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -95,6 +98,7 @@ func RegisterAlarmTools(r *toolRegistrar, clientFor ClientFactory) {
 	// update_alarm tool
 	r.AddTool(
 		mcp.NewTool("update_alarm",
+			mcp.WithTitleAnnotation("Update Alarm"),
 			mcp.WithDescription("Update an existing Insights alarm. IMPORTANT: Requires reference topics: alarms, queries, badgerql — fetch via get_reference first (skip topics still visible in your context) for the trigger_config schema and query guidelines."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -142,6 +146,7 @@ func RegisterAlarmTools(r *toolRegistrar, clientFor ClientFactory) {
 	// delete_alarm tool
 	r.AddTool(
 		mcp.NewTool("delete_alarm",
+			mcp.WithTitleAnnotation("Delete Alarm"),
 			mcp.WithDescription("Delete an Insights alarm."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -163,6 +168,7 @@ func RegisterAlarmTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_alarm_history tool
 	r.AddTool(
 		mcp.NewTool("get_alarm_history",
+			mcp.WithTitleAnnotation("Get Alarm History"),
 			mcp.WithDescription("Get the trigger history for an Insights alarm. To interpret trigger records and alarm states, fetch reference topic: alarms (via get_reference)."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),

--- a/internal/hbmcp/checkins.go
+++ b/internal/hbmcp/checkins.go
@@ -14,6 +14,7 @@ func RegisterCheckInTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_check_ins tool
 	r.AddTool(
 		mcp.NewTool("list_check_ins",
+			mcp.WithTitleAnnotation("List Check-Ins"),
 			mcp.WithDescription("List check-ins (cron/scheduled task monitoring) for a Honeybadger project. Returns the first 25 check-ins; pagination is not currently supported."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -31,6 +32,7 @@ func RegisterCheckInTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_check_in tool
 	r.AddTool(
 		mcp.NewTool("get_check_in",
+			mcp.WithTitleAnnotation("Get Check-In"),
 			mcp.WithDescription("Get a single check-in by ID"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -52,6 +54,7 @@ func RegisterCheckInTools(r *toolRegistrar, clientFor ClientFactory) {
 	// create_check_in tool
 	r.AddTool(
 		mcp.NewTool("create_check_in",
+			mcp.WithTitleAnnotation("Create Check-In"),
 			mcp.WithDescription("Create a new check-in for a Honeybadger project. Check-ins monitor cron jobs and scheduled tasks by alerting when an expected report doesn't arrive."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -93,6 +96,7 @@ func RegisterCheckInTools(r *toolRegistrar, clientFor ClientFactory) {
 	// update_check_in tool
 	r.AddTool(
 		mcp.NewTool("update_check_in",
+			mcp.WithTitleAnnotation("Update Check-In"),
 			mcp.WithDescription("Update an existing check-in. Only the provided fields are changed; fields cannot be cleared once set. The schedule type cannot be changed after creation."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -132,6 +136,7 @@ func RegisterCheckInTools(r *toolRegistrar, clientFor ClientFactory) {
 	// delete_check_in tool
 	r.AddTool(
 		mcp.NewTool("delete_check_in",
+			mcp.WithTitleAnnotation("Delete Check-In"),
 			mcp.WithDescription("Delete a check-in. This also deletes the check-in's reporting history."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),

--- a/internal/hbmcp/dashboards.go
+++ b/internal/hbmcp/dashboards.go
@@ -14,6 +14,7 @@ func RegisterDashboardTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_dashboards tool
 	r.AddTool(
 		mcp.NewTool("list_dashboards",
+			mcp.WithTitleAnnotation("List Dashboards"),
 			mcp.WithDescription("List all Insights dashboards for a Honeybadger project"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -31,6 +32,7 @@ func RegisterDashboardTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_dashboard tool
 	r.AddTool(
 		mcp.NewTool("get_dashboard",
+			mcp.WithTitleAnnotation("Get Dashboard"),
 			mcp.WithDescription("Get a single Insights dashboard by ID"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -52,6 +54,7 @@ func RegisterDashboardTools(r *toolRegistrar, clientFor ClientFactory) {
 	// create_dashboard tool
 	r.AddTool(
 		mcp.NewTool("create_dashboard",
+			mcp.WithTitleAnnotation("Create Dashboard"),
 			mcp.WithDescription("Create a new Insights dashboard for a Honeybadger project. IMPORTANT: Requires reference topics: dashboards, charts, queries, badgerql — fetch via get_reference first (skip topics still visible in your context). Verify each widget's query returns the expected results via query_insights before creating the dashboard."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -80,6 +83,7 @@ func RegisterDashboardTools(r *toolRegistrar, clientFor ClientFactory) {
 	// update_dashboard tool
 	r.AddTool(
 		mcp.NewTool("update_dashboard",
+			mcp.WithTitleAnnotation("Update Dashboard"),
 			mcp.WithDescription("Update an existing Insights dashboard. IMPORTANT: Requires reference topics: dashboards, charts, queries, badgerql — fetch via get_reference first (skip topics still visible in your context)."),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -112,6 +116,7 @@ func RegisterDashboardTools(r *toolRegistrar, clientFor ClientFactory) {
 	// delete_dashboard tool
 	r.AddTool(
 		mcp.NewTool("delete_dashboard",
+			mcp.WithTitleAnnotation("Delete Dashboard"),
 			mcp.WithDescription("Delete an Insights dashboard"),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),

--- a/internal/hbmcp/faults.go
+++ b/internal/hbmcp/faults.go
@@ -14,6 +14,7 @@ func RegisterFaultTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_faults tool
 	r.AddTool(
 		mcp.NewTool("list_faults",
+			mcp.WithTitleAnnotation("List Faults"),
 			mcp.WithDescription("Get a list of faults for a project with optional filtering and ordering. Requires reference topic: errors (fetch via get_reference; skip if still visible in your context) for the fault/notice model and the q search syntax."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -56,6 +57,7 @@ func RegisterFaultTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_fault tool
 	r.AddTool(
 		mcp.NewTool("get_fault",
+			mcp.WithTitleAnnotation("Get Fault"),
 			mcp.WithDescription("Get detailed information for a specific fault in a project"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -78,6 +80,7 @@ func RegisterFaultTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_fault_notices tool
 	r.AddTool(
 		mcp.NewTool("list_fault_notices",
+			mcp.WithTitleAnnotation("List Fault Notices"),
 			mcp.WithDescription("Get a list of notices (individual error events) for a specific fault"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -111,6 +114,7 @@ func RegisterFaultTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_fault_affected_users tool
 	r.AddTool(
 		mcp.NewTool("list_fault_affected_users",
+			mcp.WithTitleAnnotation("List Fault Affected Users"),
 			mcp.WithDescription("Get a list of users who were affected by a specific fault with occurrence counts"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -136,6 +140,7 @@ func RegisterFaultTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_fault_counts tool
 	r.AddTool(
 		mcp.NewTool("get_fault_counts",
+			mcp.WithTitleAnnotation("Get Fault Counts"),
 			mcp.WithDescription("Get fault count statistics for a project with optional filtering. Requires reference topic: errors (fetch via get_reference; skip if still visible in your context) for the q search syntax."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),

--- a/internal/hbmcp/insights.go
+++ b/internal/hbmcp/insights.go
@@ -14,6 +14,7 @@ func RegisterInsightsTools(r *toolRegistrar, clientFor ClientFactory) {
 	// query_insights tool
 	r.AddTool(
 		mcp.NewTool("query_insights",
+			mcp.WithTitleAnnotation("Query Insights"),
 			mcp.WithDescription("Execute a BadgerQL query against Insights data. Requires reference topics: queries, badgerql (fetch via get_reference; skip topics still visible in your context). To visualize or share results, also fetch the charts topic."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),

--- a/internal/hbmcp/projects.go
+++ b/internal/hbmcp/projects.go
@@ -15,6 +15,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// list_projects tool
 	r.AddTool(
 		mcp.NewTool("list_projects",
+			mcp.WithTitleAnnotation("List Projects"),
 			mcp.WithDescription("List all Honeybadger projects (returns summary info; use get_project for full details)"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -30,6 +31,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_project tool
 	r.AddTool(
 		mcp.NewTool("get_project",
+			mcp.WithTitleAnnotation("Get Project"),
 			mcp.WithDescription("Get a single Honeybadger project by ID"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -47,6 +49,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// create_project tool
 	r.AddTool(
 		mcp.NewTool("create_project",
+			mcp.WithTitleAnnotation("Create Project"),
 			mcp.WithDescription("Create a new Honeybadger project"),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -88,6 +91,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// update_project tool
 	r.AddTool(
 		mcp.NewTool("update_project",
+			mcp.WithTitleAnnotation("Update Project"),
 			mcp.WithDescription("Update an existing Honeybadger project"),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -129,6 +133,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// delete_project tool
 	r.AddTool(
 		mcp.NewTool("delete_project",
+			mcp.WithTitleAnnotation("Delete Project"),
 			mcp.WithDescription("Delete a Honeybadger project"),
 			mcp.WithReadOnlyHintAnnotation(false),
 			mcp.WithDestructiveHintAnnotation(true),
@@ -146,6 +151,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_project_occurrence_counts tool
 	r.AddTool(
 		mcp.NewTool("get_project_occurrence_counts",
+			mcp.WithTitleAnnotation("Get Project Occurrence Counts"),
 			mcp.WithDescription("Get occurrence counts for all projects or a specific project"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -169,6 +175,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_project_integrations tool
 	r.AddTool(
 		mcp.NewTool("get_project_integrations",
+			mcp.WithTitleAnnotation("Get Project Integrations"),
 			mcp.WithDescription("Get a list of integrations (channels) for a Honeybadger project"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -186,6 +193,7 @@ func RegisterProjectTools(r *toolRegistrar, clientFor ClientFactory) {
 	// get_project_report tool
 	r.AddTool(
 		mcp.NewTool("get_project_report",
+			mcp.WithTitleAnnotation("Get Project Report"),
 			mcp.WithDescription("Get report data for a Honeybadger project"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),

--- a/internal/hbmcp/reference.go
+++ b/internal/hbmcp/reference.go
@@ -169,6 +169,7 @@ func (f *referenceFetcher) index(ctx context.Context) (*instructionIndex, error)
 func RegisterReferenceTools(r *toolRegistrar, fetcher *referenceFetcher) {
 	r.AddTool(
 		mcp.NewTool("get_reference",
+			mcp.WithTitleAnnotation("Get Reference Documentation"),
 			mcp.WithDescription("Returns Honeybadger reference documentation by topic: badgerql (query language), queries (Insights query fundamentals: streams, time ranges, field grounding), charts (visualization views, chart_config), dashboards (widgets, layout), alarms (trigger_config, states, patterns), errors (fault/notice model, error search syntax). Fetch all topics you need in one call, e.g. topics: [\"badgerql\", \"charts\"]; skip topics still visible in your context. Call with no arguments for a topic index, or [\"all\"] for everything."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),
@@ -191,6 +192,7 @@ func RegisterReferenceTools(r *toolRegistrar, fetcher *referenceFetcher) {
 	// v2.0.
 	r.AddHiddenTool(
 		mcp.NewTool("get_insights_reference",
+			mcp.WithTitleAnnotation("Get Insights Reference (Deprecated)"),
 			mcp.WithDescription("Deprecated and non-functional: renamed to get_reference. Returns no content; calling it only reports that the client's tool list is out of date. Use get_reference instead."),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),

--- a/internal/hbmcp/server_test.go
+++ b/internal/hbmcp/server_test.go
@@ -2,11 +2,69 @@ package hbmcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/honeybadger-io/honeybadger-mcp-server/internal/config"
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// TestAllToolsHaveTitleAndAnnotations enforces the tool-authoring contract for
+// the Anthropic Connectors Directory: every tool exposed over tools/list must
+// carry a human-readable title annotation and an explicit readOnlyHint. This is
+// a guard against forgetting mcp.WithTitleAnnotation (or the hint) on a new
+// tool — a missing title is an automatic directory-review rejection.
+func TestAllToolsHaveTitleAndAnnotations(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:     "test-token",
+		APIURL:        "https://api.honeybadger.io/v2",
+		LogLevel:      "info",
+		ReadOnly:      false, // non-read-only so write tools are listed too
+		TransportMode: config.TransportStdio,
+	}
+
+	s := NewServer(cfg, "test")
+
+	listMsg := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	resp := s.HandleMessage(context.Background(), []byte(listMsg))
+
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("failed to marshal tools/list response: %v", err)
+	}
+
+	var parsed struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				Annotations struct {
+					Title           string `json:"title"`
+					ReadOnlyHint    *bool  `json:"readOnlyHint"`
+					DestructiveHint *bool  `json:"destructiveHint"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal tools/list response: %v", err)
+	}
+
+	if len(parsed.Result.Tools) == 0 {
+		t.Fatal("tools/list returned no tools")
+	}
+
+	for _, tool := range parsed.Result.Tools {
+		if tool.Annotations.Title == "" {
+			t.Errorf("tool %q is missing a title annotation (add mcp.WithTitleAnnotation)", tool.Name)
+		}
+		if tool.Annotations.ReadOnlyHint == nil {
+			t.Errorf("tool %q is missing a readOnlyHint annotation", tool.Name)
+		}
+		if tool.Annotations.DestructiveHint == nil {
+			t.Errorf("tool %q is missing a destructiveHint annotation", tool.Name)
+		}
+	}
+}
 
 func TestNewServer(t *testing.T) {
 	cfg := &config.Config{

--- a/internal/hbmcp/server_test.go
+++ b/internal/hbmcp/server_test.go
@@ -11,9 +11,10 @@ import (
 
 // TestAllToolsHaveTitleAndAnnotations enforces the tool-authoring contract for
 // the Anthropic Connectors Directory: every tool exposed over tools/list must
-// carry a human-readable title annotation and an explicit readOnlyHint. This is
-// a guard against forgetting mcp.WithTitleAnnotation (or the hint) on a new
-// tool — a missing title is an automatic directory-review rejection.
+// carry a human-readable title annotation plus explicit readOnlyHint and
+// destructiveHint annotations. This is a guard against forgetting
+// mcp.WithTitleAnnotation (or either hint) on a new tool — a missing title is
+// an automatic directory-review rejection.
 func TestAllToolsHaveTitleAndAnnotations(t *testing.T) {
 	cfg := &config.Config{
 		AuthToken:     "test-token",

--- a/internal/hbmcp/tool_search.go
+++ b/internal/hbmcp/tool_search.go
@@ -67,6 +67,7 @@ var searchToolInfo = ToolInfo{
 func registerSearchTool(s *server.MCPServer, catalog []ToolInfo, cfg *config.Config) {
 	s.AddTool(
 		mcp.NewTool(searchToolInfo.Name,
+			mcp.WithTitleAnnotation("Search Tools"),
 			mcp.WithDescription(searchToolInfo.Description),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDestructiveHintAnnotation(false),


### PR DESCRIPTION
Every tool now declares mcp.WithTitleAnnotation, required for the Anthropic Connectors Directory. Add TestAllToolsHaveTitleAndAnnotations as a build guard that fails if any tool is missing a title, readOnlyHint, or destructiveHint, plus a CLAUDE.md note documenting the tool-authoring convention.