### PR TITLE
feat: add update_fault tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ read-only: true
   - `project_id` : The ID of the project containing the fault (number, required)
   - `fault_id` : The ID of the fault to retrieve (number, required)
 
+- **update_fault** - Update a fault's resolved, ignored, assignee, or resolve-on-deploy state. Only the provided fields are changed.
+  - `project_id` : The ID of the project containing the fault (number, required)
+  - `fault_id` : The ID of the fault to update (number, required)
+  - `resolved` : Whether the fault is resolved (boolean, optional)
+  - `ignored` : Whether the fault is ignored (boolean, optional)
+  - `assignee_id` : Positive integer to assign that user; null to remove the current assignee; omit to leave unchanged (number or null, optional)
+  - `resolve_on_deploy` : Mark the fault to be resolved automatically on next deploy (boolean, optional)
+
 - **get_fault_counts** - Get fault count statistics for a project with optional filtering. Fetch the `errors` reference topic (via `get_reference`) for the `q` search syntax.
   - `project_id` : The ID of the project to get fault counts for (number, required)
   - `q` : Search string to filter faults (string, optional)

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ read-only: true
   - `fault_id` : The ID of the fault to update (number, required)
   - `resolved` : Whether the fault is resolved (boolean, optional)
   - `ignored` : Whether the fault is ignored (boolean, optional)
-  - `assignee_id` : Positive integer to assign that user; null to remove the current assignee; omit to leave unchanged (number or null, optional)
+  - `assignee_id` : Positive integer to assign that user; null to remove the current assignee; omit to leave unchanged (integer or null, optional)
   - `resolve_on_deploy` : Mark the fault to be resolved automatically on next deploy (boolean, optional)
 
 - **get_fault_counts** - Get fault count statistics for a project with optional filtering. Fetch the `errors` reference topic (via `get_reference`) for the `q` search syntax.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -34,7 +34,7 @@ func TestListTools(t *testing.T) {
 		t.Fatalf("Failed to list tools: %v", err)
 	}
 
-	expectedToolCount := 33 // create_alarm, create_check_in, create_dashboard, create_project, delete_alarm, delete_check_in, delete_dashboard, delete_project, get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_insights_reference, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools, update_alarm, update_check_in, update_dashboard, update_project
+	expectedToolCount := 34 // create_alarm, create_check_in, create_dashboard, create_project, delete_alarm, delete_check_in, delete_dashboard, delete_project, get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_insights_reference, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools, update_alarm, update_check_in, update_dashboard, update_fault, update_project
 	if len(tools) != expectedToolCount {
 		t.Errorf("Expected %d tools, got %d", expectedToolCount, len(tools))
 	}
@@ -57,7 +57,7 @@ func TestListTools(t *testing.T) {
 	}
 
 	// Verify all expected tools are present
-	expectedTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_insights_reference", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools", "update_alarm", "update_check_in", "update_dashboard", "update_project"}
+	expectedTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_insights_reference", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools", "update_alarm", "update_check_in", "update_dashboard", "update_fault", "update_project"}
 	for _, expectedTool := range expectedTools {
 		found := false
 		for _, foundTool := range foundTools {
@@ -127,7 +127,7 @@ func TestListToolsReadOnly(t *testing.T) {
 	}
 
 	// Verify destructive tools are NOT present
-	destructiveTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "update_alarm", "update_check_in", "update_dashboard", "update_project"}
+	destructiveTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "update_alarm", "update_check_in", "update_dashboard", "update_fault", "update_project"}
 	for _, destructiveTool := range destructiveTools {
 		for _, foundTool := range foundTools {
 			if foundTool == destructiveTool {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/honeybadger-io/api-go v0.6.1
+	github.com/honeybadger-io/api-go v0.7.0
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbc
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/honeybadger-io/api-go v0.6.1 h1:t+NWXAx0cn8vO2ojw5cXpoA69820fPS5MZstuiBAPHQ=
-github.com/honeybadger-io/api-go v0.6.1/go.mod h1:VurinfWN9qR1Bd9Zju2pIDgG1vIi5Qq3GpcsfToQiBU=
+github.com/honeybadger-io/api-go v0.7.0 h1:A/ygifqmB+r2E1XYFtpb2VB97poMjpE79H/QdqJOY4s=
+github.com/honeybadger-io/api-go v0.7.0/go.mod h1:VurinfWN9qR1Bd9Zju2pIDgG1vIi5Qq3GpcsfToQiBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/hbmcp/faults.go
+++ b/internal/hbmcp/faults.go
@@ -77,6 +77,43 @@ func RegisterFaultTools(r *toolRegistrar, clientFor ClientFactory) {
 		},
 	)
 
+	// update_fault tool
+	r.AddTool(
+		mcp.NewTool("update_fault",
+			mcp.WithTitleAnnotation("Update Fault"),
+			mcp.WithDescription("Update a fault's resolved, ignored, assignee, or resolve-on-deploy state. Only the provided fields are changed. Setting resolved or ignored to true in the same request takes precedence over resolve_on_deploy."),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithNumber("project_id",
+				mcp.Required(),
+				mcp.Description("The ID of the project containing the fault"),
+				mcp.Min(1),
+			),
+			mcp.WithNumber("fault_id",
+				mcp.Required(),
+				mcp.Description("The ID of the fault to update"),
+				mcp.Min(1),
+			),
+			mcp.WithBoolean("resolved",
+				mcp.Description("Whether the fault is resolved"),
+			),
+			mcp.WithBoolean("ignored",
+				mcp.Description("Whether the fault is ignored"),
+			),
+			mcp.WithInteger("assignee_id",
+				mcp.Description("Positive integer to assign that user; null to remove the current assignee; omit to leave unchanged"),
+				mcp.Min(1),
+				nullable,
+			),
+			mcp.WithBoolean("resolve_on_deploy",
+				mcp.Description("Mark the fault to be resolved automatically on next deploy"),
+			),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return handleUpdateFault(ctx, clientFor(ctx), req)
+		},
+	)
+
 	// list_fault_notices tool
 	r.AddTool(
 		mcp.NewTool("list_fault_notices",
@@ -218,6 +255,81 @@ func handleGetFault(ctx context.Context, client *hbapi.Client, req mcp.CallToolR
 
 	// Return JSON response
 	jsonBytes, err := json.Marshal(fault)
+	if err != nil {
+		return mcp.NewToolResultError("Failed to marshal response"), nil
+	}
+
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+func handleUpdateFault(ctx context.Context, client *hbapi.Client, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	projectID, ok := requireID(args, "project_id")
+	if !ok {
+		return mcp.NewToolResultError("project_id must be a positive integer"), nil
+	}
+
+	faultID, ok := requireID(args, "fault_id")
+	if !ok {
+		return mcp.NewToolResultError("fault_id must be a positive integer"), nil
+	}
+
+	// Only include fields that were explicitly provided, so unset fields are
+	// omitted from the request instead of being reset. Values are validated
+	// against the raw arguments because the typed getters silently coerce
+	// invalid input (e.g. null to false, 1.5 to 1).
+	params := hbapi.FaultUpdateParams{}
+
+	for _, f := range []struct {
+		name  string
+		field **bool
+	}{
+		{"resolved", &params.Resolved},
+		{"ignored", &params.Ignored},
+		{"resolve_on_deploy", &params.ResolveOnDeploy},
+	} {
+		raw, ok := args[f.name]
+		if !ok {
+			continue
+		}
+		val, ok := raw.(bool)
+		if !ok {
+			return mcp.NewToolResultError(fmt.Sprintf("%s must be a boolean", f.name)), nil
+		}
+		*f.field = &val
+	}
+
+	if raw, ok := args["assignee_id"]; ok {
+		switch v := raw.(type) {
+		case nil:
+			params.AssigneeID = hbapi.Null[int]() // explicit null unassigns the fault
+		case float64:
+			if v != float64(int(v)) || v < 1 {
+				return mcp.NewToolResultError("assignee_id must be a positive integer or null"), nil
+			}
+			params.AssigneeID = hbapi.Value(int(v))
+		case int: // arguments constructed in Go rather than decoded from JSON
+			if v < 1 {
+				return mcp.NewToolResultError("assignee_id must be a positive integer or null"), nil
+			}
+			params.AssigneeID = hbapi.Value(v)
+		default:
+			return mcp.NewToolResultError("assignee_id must be a positive integer or null"), nil
+		}
+	}
+
+	if params.Resolved == nil && params.Ignored == nil && params.AssigneeID == nil && params.ResolveOnDeploy == nil {
+		return mcp.NewToolResultError("at least one of resolved, ignored, assignee_id, or resolve_on_deploy is required"), nil
+	}
+
+	result, err := client.Faults.Update(ctx, projectID, faultID, params)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to update fault: %v", err)), nil
+	}
+
+	// Return JSON response
+	jsonBytes, err := json.Marshal(result)
 	if err != nil {
 		return mcp.NewToolResultError("Failed to marshal response"), nil
 	}

--- a/internal/hbmcp/faults.go
+++ b/internal/hbmcp/faults.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	hbapi "github.com/honeybadger-io/api-go"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -305,7 +306,7 @@ func handleUpdateFault(ctx context.Context, client *hbapi.Client, req mcp.CallTo
 		case nil:
 			params.AssigneeID = hbapi.Null[int]() // explicit null unassigns the fault
 		case float64:
-			if v != float64(int(v)) || v < 1 {
+			if v < 1 || v > maxSafeInteger || v != math.Trunc(v) {
 				return mcp.NewToolResultError("assignee_id must be a positive integer or null"), nil
 			}
 			params.AssigneeID = hbapi.Value(int(v))

--- a/internal/hbmcp/faults_test.go
+++ b/internal/hbmcp/faults_test.go
@@ -607,6 +607,8 @@ func TestHandleUpdateFault_InvalidValues(t *testing.T) {
 		{"zero assignee_id", map[string]interface{}{"assignee_id": 0}},
 		{"negative assignee_id", map[string]interface{}{"assignee_id": -1}},
 		{"string assignee_id", map[string]interface{}{"assignee_id": "42"}},
+		{"unsafe-large assignee_id", map[string]interface{}{"assignee_id": float64(1 << 54)}},
+		{"unsafe-large fault_id", map[string]interface{}{"fault_id": float64(1 << 54)}},
 	}
 
 	for _, tt := range tests {

--- a/internal/hbmcp/faults_test.go
+++ b/internal/hbmcp/faults_test.go
@@ -3,6 +3,7 @@ package hbmcp
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -452,6 +453,305 @@ func TestHandleGetFault_Error(t *testing.T) {
 	resultText := getResultText(result)
 	if !strings.Contains(resultText, "Failed to get fault") {
 		t.Error("Error message should contain 'Failed to get fault'")
+	}
+}
+
+func TestHandleUpdateFault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("expected PUT method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v2/projects/123/faults/456" {
+			t.Errorf("expected path /v2/projects/123/faults/456, got %s", r.URL.Path)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		expected := `{"fault":{"resolved":true,"assignee_id":789}}`
+		if strings.TrimSpace(string(body)) != expected {
+			t.Errorf("expected body %s, got %s", expected, string(body))
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := hbapi.NewClient().
+		WithBaseURL(server.URL).
+		WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"project_id":  123,
+				"fault_id":    456,
+				"resolved":    true,
+				"assignee_id": 789,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("expected successful result, got error: %s", getResultText(result))
+	}
+
+	var updateResult hbapi.UpdateResult
+	if err := json.Unmarshal([]byte(getResultText(result)), &updateResult); err != nil {
+		t.Errorf("Response should be valid JSON update result: %v", err)
+	}
+	if !updateResult.Success {
+		t.Error("expected Success to be true")
+	}
+}
+
+func TestHandleUpdateFault_FalseValues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		expected := `{"fault":{"resolved":false,"ignored":false}}`
+		if strings.TrimSpace(string(body)) != expected {
+			t.Errorf("expected body %s, got %s", expected, string(body))
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := hbapi.NewClient().
+		WithBaseURL(server.URL).
+		WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"project_id": 123,
+				"fault_id":   456,
+				"resolved":   false,
+				"ignored":    false,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("expected successful result, got error: %s", getResultText(result))
+	}
+}
+
+func TestHandleUpdateFault_Unassign(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		expected := `{"fault":{"assignee_id":null}}`
+		if strings.TrimSpace(string(body)) != expected {
+			t.Errorf("expected body %s, got %s", expected, string(body))
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := hbapi.NewClient().
+		WithBaseURL(server.URL).
+		WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"project_id":  123,
+				"fault_id":    456,
+				"assignee_id": nil,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("expected successful result, got error: %s", getResultText(result))
+	}
+}
+
+func TestHandleUpdateFault_InvalidValues(t *testing.T) {
+	client := hbapi.NewClient().WithAuthToken("test-token")
+
+	tests := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{"null resolved", map[string]interface{}{"resolved": nil}},
+		{"string resolved", map[string]interface{}{"resolved": "true"}},
+		{"null ignored", map[string]interface{}{"ignored": nil}},
+		{"null resolve_on_deploy", map[string]interface{}{"resolve_on_deploy": nil}},
+		{"fractional assignee_id", map[string]interface{}{"assignee_id": 1.5}},
+		{"fractional fault_id", map[string]interface{}{"fault_id": 456.9, "resolved": true}},
+		{"string project_id", map[string]interface{}{"project_id": "123", "resolved": true}},
+		{"zero assignee_id", map[string]interface{}{"assignee_id": 0}},
+		{"negative assignee_id", map[string]interface{}{"assignee_id": -1}},
+		{"string assignee_id", map[string]interface{}{"assignee_id": "42"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]interface{}{
+				"project_id": 123,
+				"fault_id":   456,
+			}
+			for k, v := range tt.args {
+				args[k] = v
+			}
+
+			result, err := handleUpdateFault(context.Background(), client, mcp.CallToolRequest{
+				Params: mcp.CallToolParams{Arguments: args},
+			})
+			if err != nil {
+				t.Fatalf("handleUpdateFault() error = %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected validation error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestUpdateFaultSchema_NullableAssigneeID(t *testing.T) {
+	tool := mcp.NewTool("update_fault",
+		mcp.WithInteger("assignee_id",
+			mcp.Description("test"),
+			mcp.Min(1),
+			nullable,
+		),
+	)
+
+	prop, ok := tool.InputSchema.Properties["assignee_id"].(map[string]any)
+	if !ok {
+		t.Fatal("assignee_id property not found in schema")
+	}
+
+	types, ok := prop["type"].([]any)
+	if !ok {
+		t.Fatalf("expected type to be an array, got %T (%v)", prop["type"], prop["type"])
+	}
+	if len(types) != 2 || types[0] != "integer" || types[1] != "null" {
+		t.Errorf(`expected type ["integer", "null"], got %v`, types)
+	}
+}
+
+func TestHandleUpdateFault_MissingProjectID(t *testing.T) {
+	client := hbapi.NewClient().WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"fault_id": 456,
+				"resolved": true,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatal("expected error result for missing project_id")
+	}
+}
+
+func TestHandleUpdateFault_MissingFaultID(t *testing.T) {
+	client := hbapi.NewClient().WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"project_id": 123,
+				"resolved":   true,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatal("expected error result for missing fault_id")
+	}
+}
+
+func TestHandleUpdateFault_NoFields(t *testing.T) {
+	client := hbapi.NewClient().WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"project_id": 123,
+				"fault_id":   456,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatal("expected error result when no updatable fields are provided")
+	}
+}
+
+func TestHandleUpdateFault_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"errors": "Assignee must be a member of the project"}`))
+	}))
+	defer server.Close()
+
+	client := hbapi.NewClient().
+		WithBaseURL(server.URL).
+		WithAuthToken("test-token")
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"project_id":  123,
+				"fault_id":    456,
+				"assignee_id": 789,
+			},
+		},
+	}
+
+	result, err := handleUpdateFault(context.Background(), client, req)
+	if err != nil {
+		t.Fatalf("handleUpdateFault() error = %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatal("expected error result for API error")
+	}
+	if !strings.Contains(getResultText(result), "Failed to update fault") {
+		t.Errorf("expected error message to mention update failure, got %s", getResultText(result))
 	}
 }
 

--- a/internal/hbmcp/helpers.go
+++ b/internal/hbmcp/helpers.go
@@ -2,6 +2,34 @@ package hbmcp
 
 import "time"
 
+// nullable is an mcp.PropertyOption that makes a property schema accept JSON
+// null in addition to its declared type, e.g. {"type": ["number", "null"]}.
+// Handlers must inspect the raw argument via req.GetArguments() to distinguish
+// an explicit null from an omitted key.
+func nullable(schema map[string]any) {
+	if t, ok := schema["type"].(string); ok {
+		schema["type"] = []any{t, "null"}
+	}
+}
+
+// requireID extracts a positive integer argument, rejecting the fractional,
+// string, and negative values that req.GetInt would silently coerce. Use for
+// resource IDs in destructive handlers, where a truncated 456.9 would target
+// the wrong resource.
+func requireID(args map[string]any, name string) (int, bool) {
+	switch v := args[name].(type) {
+	case float64:
+		if v == float64(int(v)) && v >= 1 {
+			return int(v), true
+		}
+	case int: // arguments constructed in Go rather than decoded from JSON
+		if v >= 1 {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
 // parseTimestamp converts a timestamp string to *time.Time, returns nil if empty or invalid
 func parseTimestamp(ts string) *time.Time {
 	if ts == "" {

--- a/internal/hbmcp/helpers.go
+++ b/internal/hbmcp/helpers.go
@@ -1,6 +1,14 @@
 package hbmcp
 
-import "time"
+import (
+	"math"
+	"time"
+)
+
+// maxSafeInteger is the largest integer a float64 can represent exactly
+// (2^53). JSON numbers decode to float64, so IDs above this can't round-trip
+// without silent rounding and must be rejected rather than truncated.
+const maxSafeInteger = 1 << 53
 
 // nullable is an mcp.PropertyOption that makes a property schema accept JSON
 // null in addition to its declared type, e.g. {"type": ["number", "null"]}.
@@ -19,7 +27,7 @@ func nullable(schema map[string]any) {
 func requireID(args map[string]any, name string) (int, bool) {
 	switch v := args[name].(type) {
 	case float64:
-		if v == float64(int(v)) && v >= 1 {
+		if v >= 1 && v <= maxSafeInteger && v == math.Trunc(v) {
 			return int(v), true
 		}
 	case int: // arguments constructed in Go rather than decoded from JSON


### PR DESCRIPTION
Updates a fault's resolved, ignored, assignee, and resolve-on-deploy state via the new api-go Faults.Update. Only provided fields are sent.

assignee_id is declared as ["integer", "null"] in the tool schema: a positive integer assigns, explicit null unassigns, omitted leaves unchanged. The handler validates raw arguments instead of using the coercing typed getters, so null/invalid booleans and fractional or string resource IDs return errors rather than silently mutating the wrong state (GetInt truncates 456.9 to 456; GetBool turns null into false).

Requires an api-go release containing Faults.Update before merge (go.mod still pins v0.6.1; local builds resolve via go.work).