### PR TITLE
fix: remove non-functional get_insights_reference alias

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -34,7 +34,7 @@ func TestListTools(t *testing.T) {
 		t.Fatalf("Failed to list tools: %v", err)
 	}
 
-	expectedToolCount := 34 // create_alarm, create_check_in, create_dashboard, create_project, delete_alarm, delete_check_in, delete_dashboard, delete_project, get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_insights_reference, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools, update_alarm, update_check_in, update_dashboard, update_fault, update_project
+	expectedToolCount := 33 // create_alarm, create_check_in, create_dashboard, create_project, delete_alarm, delete_check_in, delete_dashboard, delete_project, get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools, update_alarm, update_check_in, update_dashboard, update_fault, update_project
 	if len(tools) != expectedToolCount {
 		t.Errorf("Expected %d tools, got %d", expectedToolCount, len(tools))
 	}
@@ -57,7 +57,7 @@ func TestListTools(t *testing.T) {
 	}
 
 	// Verify all expected tools are present
-	expectedTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_insights_reference", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools", "update_alarm", "update_check_in", "update_dashboard", "update_fault", "update_project"}
+	expectedTools := []string{"create_alarm", "create_check_in", "create_dashboard", "create_project", "delete_alarm", "delete_check_in", "delete_dashboard", "delete_project", "get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools", "update_alarm", "update_check_in", "update_dashboard", "update_fault", "update_project"}
 	for _, expectedTool := range expectedTools {
 		found := false
 		for _, foundTool := range foundTools {
@@ -94,7 +94,7 @@ func TestListToolsReadOnly(t *testing.T) {
 		t.Fatalf("Failed to list tools: %v", err)
 	}
 
-	expectedToolCount := 21 // get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_insights_reference, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools
+	expectedToolCount := 20 // get_alarm, get_alarm_history, get_check_in, get_dashboard, get_fault, get_fault_counts, get_reference, get_project, get_project_integrations, get_project_occurrence_counts, get_project_report, list_alarms, list_check_ins, list_dashboards, list_fault_affected_users, list_fault_notices, list_faults, list_projects, query_insights, search_tools
 	if len(tools) != expectedToolCount {
 		t.Errorf("Expected %d tools in read-only mode, got %d", expectedToolCount, len(tools))
 	}
@@ -112,7 +112,7 @@ func TestListToolsReadOnly(t *testing.T) {
 	}
 
 	// Verify only read-only tools are present
-	expectedReadOnlyTools := []string{"get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_insights_reference", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools"}
+	expectedReadOnlyTools := []string{"get_alarm", "get_alarm_history", "get_check_in", "get_dashboard", "get_fault", "get_fault_counts", "get_reference", "get_project", "get_project_integrations", "get_project_occurrence_counts", "get_project_report", "list_alarms", "list_check_ins", "list_dashboards", "list_fault_affected_users", "list_fault_notices", "list_faults", "list_projects", "query_insights", "search_tools"}
 	for _, expectedTool := range expectedReadOnlyTools {
 		found := false
 		for _, foundTool := range foundTools {

--- a/internal/hbmcp/reference.go
+++ b/internal/hbmcp/reference.go
@@ -182,41 +182,7 @@ func RegisterReferenceTools(r *toolRegistrar, fetcher *referenceFetcher) {
 			return handleGetReference(ctx, fetcher, req)
 		},
 	)
-
-	// Deprecated alias: get_reference was previously named get_insights_reference.
-	// Registered hidden so it stays reachable for clients whose cached tool list
-	// still has the old name, without advertising it to fresh clients via
-	// search_tools or the landing page. It deliberately returns no reference
-	// content: its only job is to report that the tool list is stale and must be
-	// refreshed. The alias is retained for all v1.x releases; earliest removal is
-	// v2.0.
-	r.AddHiddenTool(
-		mcp.NewTool("get_insights_reference",
-			mcp.WithTitleAnnotation("Get Insights Reference (Deprecated)"),
-			mcp.WithDescription("Deprecated and non-functional: renamed to get_reference. Returns no content; calling it only reports that the client's tool list is out of date. Use get_reference instead."),
-			mcp.WithReadOnlyHintAnnotation(true),
-			mcp.WithDestructiveHintAnnotation(false),
-		),
-		handleDeprecatedInsightsReference,
-	)
 }
-
-// handleDeprecatedInsightsReference is the handler for the old
-// get_insights_reference name. It returns no reference content — reaching it at
-// all means the caller's tool list is stale — so it reports that as an error
-// result carrying instructions to refresh and switch to get_reference.
-func handleDeprecatedInsightsReference(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return mcp.NewToolResultError(deprecatedReferenceNotice), nil
-}
-
-// deprecatedReferenceNotice is the entire payload returned for the old
-// get_insights_reference name. It must be self-contained: it reaches clients
-// whose cached tool list is stale (the description they see is stale too), so it
-// carries the full instruction to refresh.
-const deprecatedReferenceNotice = "`get_insights_reference` has been renamed to `get_reference` and no longer returns content. " +
-	"Reaching this tool means the MCP client's cached tool list is out of date, so other tool names, descriptions, and " +
-	"input schemas may be stale too. Tell the user to reconnect the Honeybadger MCP server (for example, run `/mcp` and " +
-	"reconnect, or restart the client) to refresh tool definitions, then call `get_reference` for reference content."
 
 func handleGetReference(ctx context.Context, f *referenceFetcher, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	idx, err := f.index(ctx)

--- a/internal/hbmcp/reference_test.go
+++ b/internal/hbmcp/reference_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 )
 
 var testSets = []struct {
@@ -155,47 +154,6 @@ func TestHandleGetReference_All(t *testing.T) {
 	for _, s := range testSets {
 		if !strings.Contains(resultText, s.content) {
 			t.Errorf("\"all\" should include full content of topic %q", s.name)
-		}
-	}
-}
-
-func TestHandleDeprecatedInsightsReference_ReportsRenameAsError(t *testing.T) {
-	// The alias needs no docs server: it never fetches content, it only reports
-	// that the caller's tool list is stale.
-	result, err := handleDeprecatedInsightsReference(context.Background(), referenceRequest("all"))
-	if err != nil {
-		t.Fatalf("handleDeprecatedInsightsReference() error = %v", err)
-	}
-	if !result.IsError {
-		t.Fatal("alias should return an error result so the client treats the call as failed")
-	}
-
-	resultText := getResultText(result)
-	if !strings.Contains(resultText, "get_reference") {
-		t.Error("notice should point callers at get_reference")
-	}
-	if !strings.Contains(resultText, "reconnect") {
-		t.Error("notice should instruct the user to reconnect")
-	}
-	// The alias must not serve reference content — reaching it means the tool
-	// list is stale, and it exists only to say so.
-	for _, s := range testSets {
-		if strings.Contains(resultText, s.content) {
-			t.Errorf("alias must not return reference content, but included topic %q", s.name)
-		}
-	}
-}
-
-func TestDeprecatedAliasHiddenFromCatalog(t *testing.T) {
-	// The alias must stay out of search_tools / landing so fresh clients don't
-	// discover and adopt the deprecated name.
-	s := server.NewMCPServer("test", "0.0.0")
-	r := newToolRegistrar(s)
-	RegisterReferenceTools(r, testFetcher("http://example.invalid"))
-
-	for _, ti := range r.catalog {
-		if ti.Name == "get_insights_reference" {
-			t.Error("deprecated alias should not appear in the searchable catalog")
 		}
 	}
 }

--- a/internal/hbmcp/tool_search.go
+++ b/internal/hbmcp/tool_search.go
@@ -36,16 +36,6 @@ func (r *toolRegistrar) AddTool(tool mcp.Tool, handler server.ToolHandlerFunc) {
 	})
 }
 
-// AddHiddenTool registers a callable tool that is omitted from the searchable
-// catalog and the landing-page listing. It is used for deprecated aliases that
-// must stay reachable for clients whose cached tool list still names them,
-// without inviting fresh clients to discover and adopt them. The tool still
-// appears in tools/list (mcp-go has no way to route a handler otherwise), so its
-// description must make its deprecated status self-evident.
-func (r *toolRegistrar) AddHiddenTool(tool mcp.Tool, handler server.ToolHandlerFunc) {
-	r.server.AddTool(tool, handler)
-}
-
 func searchCatalog(catalog []ToolInfo, query string) []ToolInfo {
 	q := strings.ToLower(query)
 	var results []ToolInfo

--- a/internal/httptransport/landing_test.go
+++ b/internal/httptransport/landing_test.go
@@ -18,7 +18,7 @@ func testLandingHandler(t *testing.T) http.Handler {
 		Tools: []hbmcp.ToolInfo{
 			{Name: "list_projects", Description: "List all projects", ReadOnly: true},
 			{Name: "create_project", Description: "Create a new project", ReadOnly: false},
-			{Name: "create_alarm", Description: "Create a new Insights alarm. IMPORTANT: Call get_insights_reference first for full alarm documentation.", ReadOnly: false},
+			{Name: "create_alarm", Description: "Create a new Insights alarm. IMPORTANT: Call get_reference first for full alarm documentation.", ReadOnly: false},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
I did a run through with Claude, validating that each tool call works the way is expected from the Anthropic automated checks (or at least from what they say they check for.) Turns out my attempt at "deprecating" a tool with the error response violates their rules, so I guess the solution is to just get rid of the old tool and let each cached MCP deal with it 😎 . 

I thought about just keeping it around, but I don't want to confuse any agents about which reference tool call is the right one to use.